### PR TITLE
use absolute power for power transformation as per Cook and Peters

### DIFF
--- a/R/powt.R
+++ b/R/powt.R
@@ -37,7 +37,7 @@ powt <- function(rwl) {
         Xt <- x
         X.nna <- which(!is.na(x))
         X <- na.omit(x)
-        p <- fit.lm(X)
+        p <- abs(fit.lm(X))
         X2 <- X^p
         Xt[X.nna] <- X2
         Xt


### PR DESCRIPTION
In theory (and as pointed out by Feng Wang), the exponent for power transformation can be (slightly) negative. Cook and Peters (1997) just use the absolute value in this case, even if this is not reflected in the given formula.