### PR TITLE
Update chron.stabilized.R

### DIFF
--- a/R/chron.stabilized.R
+++ b/R/chron.stabilized.R
@@ -3,8 +3,8 @@
     {
         if(!is.int(winLength)) stop("'winLength' must be an integer.")
         if(winLength > nrow(x)) stop("'winLength' must be (considerably) shorter than the chronology length.")
-        if(winLength <= 30) warning("'winLength' < 30 is not reccomended.\n  Consider  a longer window.")
-        if(winLength/nrow(x) > 0.5) warning("'winLength' > 50% of chronology length is not reccomended.\n  Consider  a shorter window.")
+        if(winLength <= 30) warning("'winLength' < 30 is not recommended.\n  Consider a longer window.")
+        if(winLength/nrow(x) > 0.5) warning("'winLength' > 50% of chronology length is not recommended.\n  Consider a shorter window.")
         
         # get rbar for some window length
         rbarWinLength <-function (x, WL=winLength) {
@@ -33,18 +33,19 @@
         
         movingRbarVec <- rep(NA,nrow(x0))
         
-        # if winLength is even
-        if(winLength%%2 != 1){
-            for(i in 1:(nrow(x0)-winLength+1)){
-                movingRbarVec[i+(winLength-1)/2] <- rbarWinLength(x0[i:(i+winLength-1),])
-            } 
-        }
         # if winLength is odd
-        else{
-            for(i in 1:(nrow(x0)-winLength)){
-                movingRbarVec[i+(winLength)/2] <- rbarWinLength(x0[i:(i+winLength),])
-            } 
-        }
+    
+    if(winLength%%2 == 1){
+      for(i in 1:(nrow(x0)-winLength+1)){
+        movingRbarVec[i+(winLength-1)/2] <- rbarWinLength(x0[i:(i+winLength-1),])
+      } 
+    }
+    # if winLength is even
+    else{
+      for(i in 1:(nrow(x0)-winLength+1)){
+        movingRbarVec[i+(winLength)/2] <- rbarWinLength(x0[i:(i+winLength-1),])
+      } 
+    }
         # The 1st winLength/2 values of movingRbarVec are NA as are the 
         # last winLength/2 (depending on odd or even winLength). 
         # Pad with with first and last real values. This replaces the original call


### PR DESCRIPTION
I apologize for the botched code that I posted earlier. I must have cmd-z'ed a bit too much before copying my code in here. 

The if-clause to check if winLength is odd or even was wrong. WL%%2 ==1 asks for the modulo (the rest of the division) to be one, i.e. WL to be odd, it should have been !=0 or ==1, and not !=1 as in the code I uploaded. Also, the "else" part had an error, effectively using WL+1  (i+winLength as opposed to i+winLength-1) to calculate rbar. 

It should produce the correct amount of NAs to be padded now in both odd/even cases. 

I spell-checked your warnings. 

also: the `is.int` in the begininng is not a base function. How about asking `if(winLength!=round(winLength))` instead?