### PR TITLE
Resolving R CMD check NOTE

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
 * CHANGES IN dplR VERSION 1.7.8
 
-File: 
+File: dplR.c .h, redfit.c
+----------------
+
+- Resolved R CMD check NOTE by using a well documented, conditionally backported function instead of a non-API entrypoint
 
 * CHANGES IN dplR VERSION 1.7.7
 

--- a/src/dplR.c
+++ b/src/dplR.c
@@ -1,11 +1,23 @@
 #include "dplR.h"
 
+/*
+  Writing R Extensions: 6.21.8 Some backports (2024-07-12)
+*/
+#if R_VERSION < R_Version(4, 4, 1)
+SEXP allocLang(int n)
+{
+    if (n > 0)
+        return LCONS(R_NilValue, allocList(n - 1));
+    else
+        return R_NilValue;
+}
+#endif
+
 size_t dplRlength(SEXP x) {
     size_t xlength;
     SEXP sn, tmp, ncall;
     PROTECT_INDEX ipx;
-    PROTECT(tmp = ncall = allocList(2));
-    SET_TYPEOF(ncall, LANGSXP);
+    PROTECT(tmp = ncall = allocLang(2));
     SETCAR(tmp, install("length")); tmp = CDR(tmp);
     SETCAR(tmp, x);
     PROTECT_WITH_INDEX(sn = eval(ncall, R_BaseEnv), &ipx);

--- a/src/dplR.h
+++ b/src/dplR.h
@@ -32,4 +32,8 @@ typedef long double dplr_ldouble;
 #define R_INT_MAX 2147483647
 #define R_INT_MIN -R_INT_MAX
 
+#if R_VERSION < R_Version(4, 4, 1)
+SEXP allocLang(int n);
+#endif
+
 #endif

--- a/src/dplR.h
+++ b/src/dplR.h
@@ -15,9 +15,7 @@ size_t dplRlength(SEXP x);
 #define dngettext(pkg, String, StringP, N) (N > 1 ? StringP: String)
 #endif
 
-#if defined(R_VERSION) && R_VERSION >= R_Version(3, 0, 0)
 #define DPLR_RGEQ3
-#endif
 
 /*
   dplr_ldouble is a 64 or 80 bit floating point type

--- a/src/redfit.c
+++ b/src/redfit.c
@@ -94,16 +94,14 @@ void rmtrend(SEXP x, SEXP y, SEXP lengthfun, SEXP lmfit) {
     Rboolean mismatch = TRUE;
 
     /* dplR: call lm.fit(x, y) */
-    PROTECT(tmp = lmcall = allocList(3));
-    SET_TYPEOF(lmcall, LANGSXP);
+    PROTECT(tmp = lmcall = allocLang(3));
     SETCAR(tmp, lmfit); tmp = CDR(tmp);
     SETCAR(tmp, x); tmp = CDR(tmp);
     SETCAR(tmp, y);
     PROTECT(lmres = eval(lmcall, R_EmptyEnv));
 
     /* dplR: get residuals from the list given by lm.fit(x, y) */
-    PROTECT(tmp = ncall = allocList(2));
-    SET_TYPEOF(ncall, LANGSXP);
+    PROTECT(tmp = ncall = allocLang(2));
     SETCAR(tmp, lengthfun); tmp = CDR(tmp);
     lmnames = getAttrib(lmres, R_NamesSymbol);
     SETCAR(tmp, lmnames);
@@ -121,8 +119,7 @@ void rmtrend(SEXP x, SEXP y, SEXP lengthfun, SEXP lmfit) {
     }
 
     /* dplR: compare length of y with length of residuals */
-    PROTECT(tmp = ncall = allocList(2));
-    SET_TYPEOF(ncall, LANGSXP);
+    PROTECT(tmp = ncall = allocLang(2));
     SETCAR(tmp, lengthfun); tmp = CDR(tmp);
     SETCAR(tmp, y);
     PROTECT_WITH_INDEX(sn = eval(ncall, R_BaseEnv), &ipx);
@@ -195,8 +192,7 @@ SEXP spectr(SEXP t, SEXP x, SEXP np, SEXP ww, SEXP tsin, SEXP tcos, SEXP wtau,
      * dimensions greater than 2^31 - 1 if that is allowed in future
      * versions of R.  I don't see that limit becoming a problem,
      * though.*/
-    PROTECT(tmp = cbindcall = allocList(3));
-    SET_TYPEOF(cbindcall, LANGSXP);
+    PROTECT(tmp = cbindcall = allocLang(3));
     SETCAR(tmp, install("cbind")); tmp = CDR(tmp);
     SETCAR(tmp, ScalarReal(1.0)); tmp = CDR(tmp);
     SETCAR(tmp, twk);


### PR DESCRIPTION
Recent R-devel complained about dplR using a non-API entry point. This patch resolves the NOTE. The solution, including a backport for R older than 4.4.1, was adopted from the _Writing R Extensions_ document.

In an unrelated change, a check for R older than 3.0.0 was removed.
