### PR TITLE
Update bakker.R

### DIFF
--- a/R/bakker.R
+++ b/R/bakker.R
@@ -92,10 +92,10 @@ bakker <- function (rwl, ancillary) {
     
     
     r0 <- dat2/2*10 #if dbh in cm, if dbh in mm, then remove *10; /2 to convert to radius
-    bai <- pi * (diff(r0 * r0))
+    bai <- c(pi*(r0[1]*r0[1]),pi * (diff(r0 * r0)))
     na <- attributes(dat2)$na.action
     no.na <- n.vec[!n.vec %in% na]
-    out[no.na[-1], i] <-  bai
+    out[no.na, i] <-  bai
   }
   
   if(nrow(rwl_filled)-nrow(rwl)==0){


### PR DESCRIPTION
detected a bug, where the BAI was miscalculated in the first row of the data.frame because of the diff() function and the unreplaced DBHhist in the BAI object "out".

That should be fixed now.