### PR TITLE
Update rwi.stats.running.R

### DIFF
--- a/R/rwi.stats.running.R
+++ b/R/rwi.stats.running.R
@@ -81,7 +81,9 @@ rwi.stats.running <- function(rwi, ids=NULL, period=c("max", "common"),
             stop("'window.length' is smaller than 'min.corr.overlap'")
         }
     }
-    tmp <- normalize1(rwi, n, prewhiten)
+    rwi.mean<-round(mean(unlist(rwi),na.rm=T)) 
+    if(rwi.mean==0){rwi<-rwi+100} #this is a check whether your dataset has been detrended using difference=T, thus having a grand mean of 0. If so, it needs to be transposed by an arbitrary positive number, otherwise normalize1() messes up the dataset and can divide a series by a slightly negative value.
+    tmp <- normalize1(rwi, n, prewhiten) 
     if(!all(tmp$idx.good)) {
         warning("after prewhitening, 'rwi' contains column(s) without at least four observations",
                 call.=FALSE)


### PR DESCRIPTION
Hi Andy,

I have added a check whether the rwi dataset has been detrended using difference=T, thus having a grand mean of 0. If so, it needs to be transposed by an arbitrary positive number, otherwise normalize1() messes up the dataset and can divide a series by a slightly negative value, returning false rbar and eps values.

Right now, if people don't pay attention their stats are f***ed up. In 99% of the cases I'd say the normalize1() is not needed, but the easy workaround is to transpose the data if needed. Would be nice if this was an automatic check and operation in the function and dplR library. :-) 

Thx for updating in the next round!
Cheers,
Stefan